### PR TITLE
Add OracleLinux support

### DIFF
--- a/manifests/gems.pp
+++ b/manifests/gems.pp
@@ -18,7 +18,7 @@ class ruby::gems {
       }
     }
 
-    'RedHat', 'CentOS': {
+    'RedHat', 'CentOS', 'OracleLinux': {
       $rubygems_pkg = 'rubygems'
     }
 


### PR DESCRIPTION
Even if not officially supporting Oracle Linux, could this be merged so that I can use camptocamp/mcollective?

Alternatively, is mcollective's dependency on this module strictly necessary, or could it be made optional somehow?

Thanks,
Alex
